### PR TITLE
ensure that job_id is Mango::BSON object

### DIFF
--- a/lib/Minion/Backend/Mango.pm
+++ b/lib/Minion/Backend/Mango.pm
@@ -2,7 +2,7 @@ package Minion::Backend::Mango;
 use Mojo::Base 'Minion::Backend';
 
 use Mango;
-use Mango::BSON 'bson_time';
+use Mango::BSON qw(bson_time bson_oid);
 use Scalar::Util 'weaken';
 use Sys::Hostname 'hostname';
 
@@ -58,7 +58,7 @@ sub fail_job { shift->_update(1, @_) }
 
 sub finish_job { shift->_update(0, @_) }
 
-sub job_info { $_[0]->_job_info($_[0]->jobs->find_one($_[1])) }
+sub job_info { $_[0]->_job_info($_[0]->jobs->find_one(bson_oid $_[1])) }
 
 sub list_jobs    { shift->_list('jobs',    'state', @_) }
 sub list_workers { shift->_list('workers', 'pid',   @_) }


### PR DESCRIPTION
This patch fixed bug with show info about job in minion command

``` bash
./script/app minion job 538e169a5fbd2d0ed9bc0000
Can't use string ("538e169a5fbd2d0ed9bc0000") as a HASH ref while "strict refs" in use at /home/and/perl5/perlbrew/perls/perl-5.20.0/lib/site_perl/5.20.0/Mango/BSON.pm line 87.
```
