### PR TITLE
don't get new jobs if worker is finished

### DIFF
--- a/lib/Minion/Command/minion/worker.pm
+++ b/lib/Minion/Command/minion/worker.pm
@@ -51,6 +51,9 @@ sub _work {
   my $jobs = $self->{jobs} ||= {};
   $jobs->{$_}->is_finished($_) and delete $jobs->{$_} for keys %$jobs;
 
+  # Check if worker are finished
+  sleep 1 and return if $self->{finished};
+
   # Wait if job limit has been reached
   if ($self->{max} <= keys %$jobs) { sleep 1 }
 


### PR DESCRIPTION
Usefull for a-la hot deploy workers by sending SIGTERM for old worker and create a new minion worker process. For now worker will try get new jobs event if it get a finished signal.