### PR TITLE
Add an enqueue event

### DIFF
--- a/lib/Minion.pm
+++ b/lib/Minion.pm
@@ -20,7 +20,12 @@ our $VERSION = '5.03';
 
 sub add_task { ($_[0]->tasks->{$_[1]} = $_[2]) and return $_[0] }
 
-sub enqueue { shift->backend->enqueue(@_) }
+sub enqueue {
+  my $self = shift;
+  my $id = $self->backend->enqueue(@_);
+  $self->emit(enqueue => $id);
+  return $id;
+}
 
 sub job {
   my ($self, $id) = @_;
@@ -194,6 +199,20 @@ Which are loaded like any other plugin from your application.
 
 L<Minion> inherits all events from L<Mojo::EventEmitter> and can emit the
 following new ones.
+
+=head2 enqueue
+
+  $minion->on(enqueue => sub {
+    my ($minion, $id) = @_;
+    ...
+  });
+
+Emitted after a job has been enqueued, in the process that enqueued it.
+
+  $minion->on(enqueue => sub {
+    my ($minion, $id) = @_;
+    say "Job $id has been enqueued.";
+  });
 
 =head2 worker
 

--- a/t/pg.t
+++ b/t/pg.t
@@ -357,8 +357,10 @@ $worker->unregister;
 
 # Events
 my $pid;
+my $enqueue;
 my $failed = 0;
 $finished = 0;
+$minion->once(enqueue => sub { $enqueue = pop });
 $minion->once(
   worker => sub {
     my ($minion, $worker) = @_;
@@ -380,7 +382,8 @@ $minion->once(
   }
 );
 $worker = $minion->worker->register;
-$minion->enqueue(add => [3, 3]);
+$id = $minion->enqueue(add => [3, 3]);
+is $enqueue, $id, 'emit correct event';
 $minion->enqueue(add => [4, 3]);
 $job = $worker->dequeue(0);
 is $failed,   0, 'failed event has not been emitted';


### PR DESCRIPTION
This would be useful for monitoring tools and front-ends to be push-notified on enqueuing of new jobs without having to modify application logic to do the notifications in the task callbacks.