### PR TITLE
add default for enqueue option delay in POD

### DIFF
--- a/lib/Minion.pm
+++ b/lib/Minion.pm
@@ -351,7 +351,7 @@ L</"backoff"> after the first attempt, defaults to C<1>.
 
   delay => 10
 
-Delay job for this many seconds (from now).
+Delay job for this many seconds (from now), defaults to C<0>.
 
 =item parents
 

--- a/lib/Minion/Backend.pm
+++ b/lib/Minion/Backend.pm
@@ -165,7 +165,7 @@ L<Minion/"backoff"> after the first attempt, defaults to C<1>.
 
   delay => 10
 
-Delay job for this many seconds (from now).
+Delay job for this many seconds (from now), defaults to C<0>.
 
 =item parents
 

--- a/lib/Minion/Backend/Pg.pm
+++ b/lib/Minion/Backend/Pg.pm
@@ -376,7 +376,7 @@ L<Minion/"backoff"> after the first attempt, defaults to C<1>.
 
   delay => 10
 
-Delay job for this many seconds (from now).
+Delay job for this many seconds (from now), defaults to C<0>.
 
 =item parents
 


### PR DESCRIPTION
Explicitly include the default for the delay option to keep in line with the rest of the enqueue options.