### PR TITLE
Worker and job classes for extensibility

### DIFF
--- a/lib/Minion.pm
+++ b/lib/Minion.pm
@@ -15,6 +15,7 @@ has backoff => sub { \&_backoff };
 has missing_after => 1800;
 has remove_after  => 172800;
 has tasks         => sub { {} };
+has worker_class  => 'Minion::Worker';
 
 our $VERSION = '6.05';
 
@@ -71,7 +72,7 @@ sub worker {
   # No fork emulation support
   croak 'Minion workers do not support fork emulation' if $Config{d_pseudofork};
 
-  my $worker = Minion::Worker->new(minion => $self);
+  my $worker = $self->worker_class->new(minion => $self);
   $self->emit(worker => $worker);
   return $worker;
 }
@@ -306,6 +307,14 @@ L</"repair">, defaults to C<172800> (2 days).
 
 Registered tasks.
 
+=head2 worker_class
+
+  my $class = $minion->worker_class;
+  $minion   = $minion->worker_class('MyApp::Worker');
+
+Class to be used by L</"worker">, defaults to L<Minion::Worker>. Note that
+this class needs to have already been loaded before L</"worker"> is called.
+
 =head1 METHODS
 
 L<Minion> inherits all methods from L<Mojo::EventEmitter> and implements the
@@ -499,7 +508,8 @@ Number of workers that are currently not processing a job.
 
   my $worker = $minion->worker;
 
-Build L<Minion::Worker> object.
+Build a worker object based on L</"worker_class">
+(which is usually L<Minion::Worker>).
 
 =head1 REFERENCE
 

--- a/lib/Minion.pm
+++ b/lib/Minion.pm
@@ -73,7 +73,7 @@ sub worker {
   # No fork emulation support
   croak 'Minion workers do not support fork emulation' if $Config{d_pseudofork};
 
-  my $worker = $self->worker_class->new(minion => $self);
+  my $worker = $self->worker_class->new(minion => $self, @_);
   $self->emit(worker => $worker);
   return $worker;
 }

--- a/lib/Minion/Worker.pm
+++ b/lib/Minion/Worker.pm
@@ -14,7 +14,7 @@ sub dequeue {
 
   my $minion = $self->minion;
   return undef unless my $job = $minion->backend->dequeue($id, $wait, $options);
-  $job = Minion::Job->new(
+  $job = $minion->job_class->new(
     args    => $job->{args},
     id      => $job->{id},
     minion  => $minion,
@@ -130,7 +130,7 @@ Register a worker remote control command.
   my $job = $worker->dequeue(0.5);
   my $job = $worker->dequeue(0.5 => {queues => ['important']});
 
-Wait a given amount of time in seconds for a job, dequeue L<Minion::Job> object
+Wait a given amount of time in seconds for a job, dequeue a job object
 and transition from C<inactive> to C<active> state, or return C<undef> if queues
 were empty.
 


### PR DESCRIPTION
### Summary
This adds `job_class` and `worker_class` to Minion with the natural defaults as `Minion::Job` and `Minion::Worker`.

### Motivation
It makes easier to introduce small behavior changes with custom job and worker classes.

### References
none so far

### Caveats
A very simple test has been added.