### PR TITLE
Take advantage of the index on "parents" in repair()

### DIFF
--- a/lib/Minion/Backend/Pg.pm
+++ b/lib/Minion/Backend/Pg.pm
@@ -157,7 +157,7 @@ sub repair {
     "delete from minion_jobs as j
      where finished <= now() - interval '1 second' * ? and not exists (
        select 1 from minion_jobs
-       where j.id = any(parents) and state <> 'finished'
+       where parents @> ARRAY[j.id] and state <> 'finished'
      ) and state = 'finished'", $minion->remove_after
   );
 }


### PR DESCRIPTION
### Summary
At work, when the "minion_jobs" table accumulated almost 1.5M rows satisfying the "Old jobs with no unresolved dependencies" condition, the workers hanged while trying to prune these rows.

After some research, I found this is related to the fact that the commit https://github.com/kraih/minion/commit/a42fae8a19439f1095c5b55bcca18f5b638a1ee3 which introduced the GIN index on minion_jobs.parents didn't touch the corresponding DELETE statement.

This PR takes care of that.

### Motivation
The query plan for the query in question changes from

```
minion=> explain delete from minion_jobs as j  where finished <= now() - interval '1 second' * 172800 and not exists (   select 1 from minion_jobs     where j.id = ANY(parents)   ) and state = 'finished';
                                                    QUERY PLAN                                                     
-------------------------------------------------------------------------------------------------------------------
 Delete on minion_jobs j  (cost=6768.70..277557.06 rows=1 width=12)
   ->  Nested Loop Anti Join  (cost=6768.70..277557.06 rows=1 width=12)
         Join Filter: (j.id = ANY (minion_jobs.parents))
         ->  Bitmap Heap Scan on minion_jobs j  (cost=6768.70..130836.17 rows=1 width=14)
               Recheck Cond: (state = 'finished'::minion_state)
               Filter: (finished <= (now() - '48:00:00'::interval))
               ->  Bitmap Index Scan on minion_jobs_state_priority_id_idx  (cost=0.00..6768.70 rows=89636 width=0)
                     Index Cond: (state = 'finished'::minion_state)
         ->  Seq Scan on minion_jobs  (cost=0.00..141356.81 rows=1312381 width=19)
(9 rows)
```

(where a full scan on minion_jobs is done) to

```
minion=> explain delete from minion_jobs as j  where finished <= now() - interval '1 second' * 172800 and not exists (   select 1 from minion_jobs     where parents @> ARRAY[j.id]   ) and state = 'finished';
                                                    QUERY PLAN                                                     
-------------------------------------------------------------------------------------------------------------------
 Delete on minion_jobs j  (cost=9303.55..133374.32 rows=1 width=12)
   ->  Nested Loop Anti Join  (cost=9303.55..133374.32 rows=1 width=12)
         ->  Bitmap Heap Scan on minion_jobs j  (cost=6768.70..130836.17 rows=1 width=14)
               Recheck Cond: (state = 'finished'::minion_state)
               Filter: (finished <= (now() - '48:00:00'::interval))
               ->  Bitmap Index Scan on minion_jobs_state_priority_id_idx  (cost=0.00..6768.70 rows=89636 width=0)
                     Index Cond: (state = 'finished'::minion_state)
         ->  Bitmap Heap Scan on minion_jobs  (cost=2534.85..23924.54 rows=6562 width=19)
               Recheck Cond: (parents @> ARRAY[j.id])
               ->  Bitmap Index Scan on minion_jobs_parents_idx  (cost=0.00..2533.21 rows=6562 width=0)
                     Index Cond: (parents @> ARRAY[j.id])
(11 rows)
```

which uses the GIN index and seems faster in the few experiments I tried.

### References
NONE YET