### PR TITLE
fix [heartbeat_interval] sec wait after boot in worker command

### DIFF
--- a/lib/Minion/Command/minion/worker.pm
+++ b/lib/Minion/Command/minion/worker.pm
@@ -51,7 +51,7 @@ sub _work {
   # Send heartbeats in regular intervals
   my $worker = $self->{worker};
   my $status = $worker->status;
-  $self->{last_heartbeat} ||= 0;
+  $self->{last_heartbeat} ||= -$status->{heartbeat_interval};
   $worker->register and $self->{last_heartbeat} = steady_time
     if ($self->{last_heartbeat} + $status->{heartbeat_interval}) < steady_time;
 


### PR DESCRIPTION
### Summary
After boot the started worker would spend the amount of seconds defined by the heartbeat_interval not dequeuing any jobs but continuously looping through the following loop in a high cpu cycle fashion:

`eval { $self->_work until $self->{finished} && !keys %{$self->{jobs}}; 1 }`

With a default heartbeat_interval value of 5 minutes for the worker command this can be a long time. 

The reason for this behaviour was that CLOCK_MONOTONIC on linux systems seems to use boot time as reference so that this condition never evaluated true for the time of one heartbeat_interval:

`$worker->register and $self->{last_heartbeat} = steady_time`
`if ($self->{last_heartbeat} + $status->{heartbeat_interval}) < steady_time;`


The fix sets the initial value for "last_heartbeat" to a negated heartbeat_interval so the worker can register immediately.