### PR TITLE
make negative remove_after disable auto-removal of jobs

### DIFF
--- a/lib/Minion.pm
+++ b/lib/Minion.pm
@@ -308,7 +308,7 @@ C<1800> (30 minutes).
 
 Amount of time in seconds after which jobs that have reached the state
 C<finished> and have no unresolved dependencies will be removed automatically by
-L</"repair">, defaults to C<172800> (2 days).
+L</"repair">, defaults to C<172800> (2 days). Negative values disable this removal.
 
 =head2 tasks
 

--- a/lib/Minion/Backend/Pg.pm
+++ b/lib/Minion/Backend/Pg.pm
@@ -165,7 +165,7 @@ sub repair {
        select 1 from minion_jobs
        where parents @> ARRAY[j.id] and state != 'finished'
      ) and state = 'finished'", $minion->remove_after
-  );
+  ) unless $minion->remove_after < 0;
 }
 
 sub reset {


### PR DESCRIPTION
### Summary
Setting remove_after to a negative value now disables the automatic removal by "repair".

### Motivation
I want to be able to disable the auto-removal for a workflow system (human workers) using Minion as a backend. Allowing any negative value means it can be set it to the negative equivalent (-172800) and still be used (e.g. the interface can still prompt for manual removal after that time).