### PR TITLE
Add worker dequeue_interval attribute to control the dequeue poll rate

### DIFF
--- a/lib/Minion/Worker.pm
+++ b/lib/Minion/Worker.pm
@@ -6,6 +6,7 @@ use Mojo::Util 'steady_time';
 
 has [qw(commands status)] => sub { {} };
 has [qw(id minion)];
+has dequeue_interval => 5;
 
 sub add_command { $_[0]->commands->{$_[1]} = $_[2] and return $_[0] }
 
@@ -116,7 +117,7 @@ sub _work {
   if (($status->{jobs} <= keys %$jobs) || $self->{finished}) { sleep 1 }
 
   # Try to get more jobs
-  elsif (my $job = $self->dequeue(5 => {queues => $status->{queues}})) {
+  elsif (my $job = $self->dequeue($self->dequeue_interval => {queues => $status->{queues}})) {
     $jobs->{my $id = $job->id} = $job->start;
     my ($pid, $task) = ($job->pid, $job->task);
   }

--- a/lib/Minion/Worker.pm
+++ b/lib/Minion/Worker.pm
@@ -185,6 +185,13 @@ L<Minion::Worker> implements the following attributes.
 
 Registered worker remote control commands.
 
+=head2 dequeue_interval
+
+  my $interval = $worker->dequeue_interval;
+  $worker      = $worker->dequeue_interval(2);
+
+The rate in seconds at which the worker will poll for additional jobs to dequeue.
+
 =head2 id
 
   my $id  = $worker->id;

--- a/t/pg_worker.t
+++ b/t/pg_worker.t
@@ -34,6 +34,9 @@ my $id = $minion->enqueue('test');
 $worker->run;
 is_deeply $minion->job($id)->info->{result}, {just => 'works!'}, 'right result';
 
+# Dequeue interval
+is $worker->dequeue_interval, 5, 'right value';
+
 # Status
 my $status = $worker->status;
 is $status->{command_interval},   10,  'right value';


### PR DESCRIPTION
### Summary
This change adds a new 'dequeue_interval' attribute to the worker that allows the poll time to be configurable.

### Motivation
I was needing a faster poll time than the default 5s.

### References
None I am aware of.
