### PR TITLE
Do not create an extra Mojo::Pg object

### DIFF
--- a/lib/Minion/Backend/Pg.pm
+++ b/lib/Minion/Backend/Pg.pm
@@ -108,10 +108,9 @@ sub lock {
 sub new {
   my $self = shift->SUPER::new(pg => Mojo::Pg->new(@_));
 
-  my $db = Mojo::Pg->new(@_)->db;
+  my $db = $self->pg->db;
   croak 'PostgreSQL 9.5 or later is required'
     if $db->dbh->{pg_server_version} < 90500;
-  $db->disconnect;
 
   $self->pg->auto_migrate(1)->migrations->name('minion')->from_data;
 


### PR DESCRIPTION
Idea: reuse the existing Mojo::Pg object when checking the db version
