### PR TITLE
add parents option to job retry

### DIFF
--- a/lib/Minion/Backend.pm
+++ b/lib/Minion/Backend.pm
@@ -589,6 +589,12 @@ Number of times performing this job will be attempted.
 
 Delay job for this many seconds (from now), defaults to C<0>.
 
+=item parents
+
+  parents => [$id1, $id2, $id3]
+
+Jobs this job depends on.
+
 =item priority
 
   priority => 5

--- a/lib/Minion/Backend/Pg.pm
+++ b/lib/Minion/Backend/Pg.pm
@@ -197,11 +197,12 @@ sub retry_job {
     "update minion_jobs
      set attempts = coalesce(?, attempts),
        delayed = (now() + (interval '1 second' * ?)),
-       priority = coalesce(?, priority), queue = coalesce(?, queue),
-       retried = now(), retries = retries + 1, state = 'inactive'
+       parents = coalesce(?, parents), priority = coalesce(?, priority),
+       queue = coalesce(?, queue), retried = now(), retries = retries + 1,
+       state = 'inactive'
      where id = ? and retries = ?
      returning 1", $options->{attempts}, $options->{delay} // 0,
-    @$options{qw(priority queue)}, $id, $retries
+    @$options{qw(parents priority queue)}, $id, $retries
   )->rows;
 }
 
@@ -825,6 +826,12 @@ Number of times performing this job will be attempted.
   delay => 10
 
 Delay job for this many seconds (from now), defaults to C<0>.
+
+=item parents
+
+  parents => [$id1, $id2, $id3]
+
+Jobs this job depends on.
 
 =item priority
 

--- a/lib/Minion/Job.pm
+++ b/lib/Minion/Job.pm
@@ -442,6 +442,12 @@ Number of times performing this job will be attempted.
 
 Delay job for this many seconds (from now), defaults to C<0>.
 
+=item parents
+
+  parents => [$id1, $id2, $id3]
+
+Jobs this job depends on.
+
 =item priority
 
   priority => 5

--- a/t/pg.t
+++ b/t/pg.t
@@ -776,6 +776,15 @@ $id = $minion->enqueue(test => [] => {parents => [-1]});
 $job = $worker->dequeue(0);
 is $job->id, $id, 'right id';
 ok $job->finish, 'job finished';
+$id = $minion->enqueue(test => [] => {parents => [-1]});
+$job = $worker->dequeue(0);
+is $job->id, $id, 'right id';
+is_deeply $job->info->{parents}, [-1], 'right parents';
+$job->retry({parents => [-1, -2]});
+$job = $worker->dequeue(0);
+is $job->id, $id, 'right id';
+is_deeply $job->info->{parents}, [-1, -2], 'right parents';
+ok $job->finish, 'job finished';
 $worker->unregister;
 
 # Foreground


### PR DESCRIPTION
### Summary
Tasks are now able to have their parents changed, which allows for them to enqueue their own prerequisite tasks or for another process to add these prerequisite tasks after enqueuing.

### Motivation
Some tasks may be enqueued months in advance of them being required and additional tasks may need be completed before they are allowed to run/be finished, that weren't known at enqueue time. This prevents needing to recreate these tasks, and every task that depends on them, to deal with the new task(s).

sri noted that this also makes the options that can be given to retry() consistent with enqueue().

### References
This was [discussed on IRC](https://irclog.perlgeek.de/mojo/2018-03-06#i_15890065).
