### PR TITLE
refresh history graph every 10 minutes

### DIFF
--- a/lib/Mojolicious/Plugin/Minion/Admin.pm
+++ b/lib/Mojolicious/Plugin/Minion/Admin.pm
@@ -19,6 +19,7 @@ sub register {
 
   # Routes
   $prefix->get('/'      => \&_dashboard)->name('minion_dashboard');
+  $prefix->get('/history' => \&_history)->name('minion_history');
   $prefix->get('/stats' => \&_stats)->name('minion_stats');
   $prefix->get('/jobs'  => \&_list_jobs)->name('minion_jobs');
   $prefix->patch('/jobs' => \&_manage_jobs)->name('minion_manage_jobs');
@@ -31,6 +32,11 @@ sub _dashboard {
   my $c = shift;
   my $history = $c->minion->backend->history;
   $c->render('minion/dashboard', history => $history);
+}
+
+sub _history {
+  my $c = shift;
+  $c->render(json => $c->minion->history);
 }
 
 sub _list_jobs {

--- a/lib/Mojolicious/Plugin/Minion/resources/templates/minion/dashboard.html.ep
+++ b/lib/Mojolicious/Plugin/Minion/resources/templates/minion/dashboard.html.ep
@@ -3,6 +3,7 @@
 % content_for head => begin
   <script>
     var chart;
+    var historychart;
     var backlog = 0;
     function pageStats(data) {
       $('.minion-stats-uptime').text(Math.round(data.uptime / 86400));
@@ -32,22 +33,37 @@
       }
       setTimeout(updateBacklogChart, 1000);
     }
+    function updateHistoryChart() {
+      $.get('<%= url_for 'minion_history' %>').done(function (data) {
+        var hour;
+        var historylog = [];
+        for (hour = 0; hour < data.daily.length; hour++) { 
+          historylog.push({
+            x: data.daily[hour].hour,
+            y: data.daily[hour].finished_jobs + data.daily[hour].failed_jobs
+          });
+        }
+        if (historychart == null) {
+          historychart = $('#history-chart').epoch({
+            type: 'bar',
+            tickFormats: {
+              bottom: function (d) { return ('0' + d).slice(-2) + ':00' }
+            },
+            data: [{
+              label: 'processed',
+              values: historylog
+            }]
+          });
+        }
+        else {
+          historychart.update([{label: 'processed', values: historylog}]);
+        }
+        setTimeout(updateHistoryChart, 1000 * 60 * 10);
+      }).fail(function () { setTimeout(updateHistoryChart, 1000 * 60) });
+    }
     $(function () {
       updateBacklogChart();
-      $('#history-chart').epoch({
-        type: 'bar',
-        data: [{
-          label: 'processed',
-          values: [
-            % for my $hour (@{$history->{daily}}) {
-              {
-                x: '<%= sprintf '%02d:00', $hour->{hour} %>',
-                y: <%= $hour->{finished_jobs} + $hour->{failed_jobs} %>
-              },
-            % }
-          ]
-        }]
-      });
+      updateHistoryChart();
     });
   </script>
 % end


### PR DESCRIPTION
### Summary
For those of us that keep the Admin UI dashboard open for longer periods of time, it might be nice to have the history graph automatically refresh every 10 minutes.

### Motivation
@kraih asked for volunteers for issue #70

### References
Refresh history graph every 10 minutes #70
