### PR TITLE
Remove references to popper.js

### DIFF
--- a/lib/Minion.pm
+++ b/lib/Minion.pm
@@ -1134,12 +1134,6 @@ L<http://scripts.sil.org/OFL>.
 
 Licensed under the MIT License, L<http://creativecommons.org/licenses/MIT>.
 
-=head2 popper.js
-
-  Copyright (C) Federico Zivolo 2017.
-
-Licensed under the MIT License, L<http://creativecommons.org/licenses/MIT>.
-
 =head1 AUTHORS
 
 =head2 Project Founder

--- a/lib/Mojolicious/Plugin/Minion/resources/templates/layouts/minion.html.ep
+++ b/lib/Mojolicious/Plugin/Minion/resources/templates/layouts/minion.html.ep
@@ -3,7 +3,6 @@
     <title><%= title() || 'Minion' %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     %= javascript '/mojo/jquery/jquery.js'
-    %= javascript '/minion/popper/popper.js'
     %= javascript '/minion/bootstrap/bootstrap.js'
     %= stylesheet '/minion/bootstrap/bootstrap.css'
     %= javascript '/minion/moment/moment.js'


### PR DESCRIPTION
### Summary
Remove references to popper.js

### Motivation
Remove unused code that refers to files no longer distributed in Minion.

### References
#114
