### PR TITLE
Update libpq* in build images

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        codename:
+          - buster
         perl-version:
           - '5.16'
           - '5.18'
@@ -18,7 +20,7 @@ jobs:
           - '5.22'
           - '5.30'
     container:
-      image: perl:${{ matrix.perl-version }}
+      image: perl:${{ matrix.perl-version }}-${{ matrix.codename }}
     services:
       postgres:
         image: postgres
@@ -26,6 +28,10 @@ jobs:
           POSTGRES_PASSWORD: postgres
     steps:
       - uses: actions/checkout@v2
+      - name: upgrade libpq
+        run: |
+          curl https://salsa.debian.org/postgresql/postgresql-common/raw/master/pgdg/apt.postgresql.org.sh | bash
+          apt-get -y update && apt-get -y upgrade
       - name: perl -V
         run: perl -V
       - name: Fix ExtUtils::MakeMaker (for Perl 5.16 and 5.18)


### PR DESCRIPTION
### Summary
Update to the images running CI to resolve failures related to Postgres image update.
`SCRAM authentication requires libpq version 10 or above`

### Motivation
Keep CI builds building.

### References
Error seen in #115 from unrelated code changes.
