### PR TITLE
added parentheses to fix precedence

### DIFF
--- a/lib/Minion.pm
+++ b/lib/Minion.pm
@@ -41,7 +41,7 @@ sub broadcast { shift->backend->broadcast(@_) }
 sub class_for_task {
   my ($self, $task) = @_;
   my $class = $self->tasks->{$task};
-  return !$class || ref $class ? 'Minion::Job' : $class;
+  return (!$class || ref $class) ? 'Minion::Job' : $class;
 }
 
 sub enqueue {


### PR DESCRIPTION
### Summary
Wrapped two terms and an operator with parentheses to fix an error in precedence.

### Motivation
Without this change, $minion->class_for_task sometimes returns `1` instead of a class name.
